### PR TITLE
Feature/issue30

### DIFF
--- a/gwp.go
+++ b/gwp.go
@@ -110,7 +110,7 @@ func (s *WorkerServer) Workers() []*worker.Worker {
 	return v
 }
 
-// Workers return the slice of #Worker configured
+// Healthy return true or false if the WorkerServer its ok or no, respectively
 func (s *WorkerServer) Healthy() bool {
 	status := true
 	for _, healthy := range s.healthy {

--- a/monitor/healthcheck/healthcheck.go
+++ b/monitor/healthcheck/healthcheck.go
@@ -13,16 +13,8 @@ func Handler(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	status := true
-	for _, worker := range runtime.GetServerRun().Workers() {
-		if !worker.IsUp() {
-			status = false
-			break
-		}
-	}
-
 	writer.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(writer).Encode(map[string]interface{}{
-		"status": status,
+		"status": runtime.GetServerRun().Healthy(),
 	})
 }

--- a/monitor/healthcheck/healthcheck_test.go
+++ b/monitor/healthcheck/healthcheck_test.go
@@ -51,8 +51,8 @@ func TestHandler(t *testing.T) {
 		t.Errorf("Error when decode body responde: %v", err)
 	}
 
-	if body["status"].(bool) {
-		t.Errorf("Was expected the status false but returned %t", body["status"].(bool))
+	if !body["status"].(bool) {
+		t.Errorf("Was expected the status true but returned %t", body["status"].(bool))
 	}
 
 	req, err = http.NewRequest(http.MethodPost, "/health-check", nil)
@@ -70,6 +70,10 @@ func TestHandler(t *testing.T) {
 }
 
 type HCFakeServer struct{}
+
+func (s HCFakeServer) Healthy() bool {
+	return true
+}
 
 func (HCFakeServer) Workers() []*worker.Worker {
 	w := worker.NewWorker("w1", func() error {

--- a/monitor/stats/stats_test.go
+++ b/monitor/stats/stats_test.go
@@ -71,6 +71,10 @@ func TestHandler(t *testing.T) {
 
 type STFakeServer struct{}
 
+func (s STFakeServer) Healthy() bool {
+	return true
+}
+
 func (STFakeServer) Workers() []*worker.Worker {
 	w := worker.NewWorker("w1", func() error {
 		return nil

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -22,3 +22,11 @@ func GetServerRun() Server {
 func (f FakeServer) Workers() []*worker.Worker {
 	return []*worker.Worker{}
 }
+
+//Healthy return the health of server
+func (f FakeServer) Healthy() bool {
+	return true
+}
+
+
+

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -24,3 +24,10 @@ func TestFakeServer_Workers(t *testing.T) {
 		t.Error("FakeServer should return empty slice")
 	}
 }
+
+func TestFakeServer_Healthy(t *testing.T) {
+	var f FakeServer
+	if !f.Healthy() {
+		t.Error("FakeServer should return true healthy, but returned false")
+	}
+}

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -6,6 +6,11 @@ type (
 	//Server interface that define the contract to be used between monitor.http and workerServer
 	Server interface {
 		Workers() []*worker.Worker
+		Healthy() bool
+	}
+
+	CheckHealthy interface {
+		Healthy() bool
 	}
 
 	//FakeServer interface that define the contract to be used between monitor.http and workerServer

--- a/runtime/types.go
+++ b/runtime/types.go
@@ -9,10 +9,6 @@ type (
 		Healthy() bool
 	}
 
-	CheckHealthy interface {
-		Healthy() bool
-	}
-
 	//FakeServer interface that define the contract to be used between monitor.http and workerServer
 	//for tests only
 	FakeServer struct{}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -59,7 +59,7 @@ func (w *Worker) Status() map[string]string {
 
 // IsUp check if anyone #SubWorker still #STARTED,
 // this survey responds if it is running
-func (w *Worker) IsUp() bool {
+func (w *Worker) Healthy() bool {
 	for _, v := range w.Status() {
 		if v == STARTED {
 			return true

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -121,7 +121,7 @@ func TestWorker_Status(t *testing.T) {
 	}
 }
 
-func TestWorker_IsUp(t *testing.T) {
+func TestWorker_Healthy(t *testing.T) {
 	nameWorker := "w1"
 	handleWorker := func() error {
 		<-time.After(3 * time.Second)
@@ -136,11 +136,11 @@ func TestWorker_IsUp(t *testing.T) {
 		close(errors)
 	}()
 	<-time.After(1 * time.Second)
-	if !w.IsUp() {
+	if !w.Healthy() {
 		t.Errorf("Was expect that worker is Up, but returned: Down")
 	}
 	<-time.After(3 * time.Second)
-	if w.IsUp() {
+	if w.Healthy() {
 		t.Errorf("Was expect that worker is Down, but returned: Up")
 	}
 }


### PR DESCRIPTION
The changes were discarded due to the complexity of the administration of the amqp connection, so that the forms of integrity verification become more flexible, the client can better manage the health of the WorkerServer without having to reimplement it.